### PR TITLE
Update GitHub demos with active projects and latest NuGet packages for Word Library

### DIFF
--- a/Change-Tab-Leader-of-TOC/Console-App-.NET-Framework/Change-Tab-Leader-of-TOC/App.config
+++ b/Change-Tab-Leader-of-TOC/Console-App-.NET-Framework/Change-Tab-Leader-of-TOC/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
     </startup>
 </configuration>

--- a/Change-Tab-Leader-of-TOC/Console-App-.NET-Framework/Change-Tab-Leader-of-TOC/Change-Tab-Leader-of-TOC.csproj
+++ b/Change-Tab-Leader-of-TOC/Console-App-.NET-Framework/Change-Tab-Leader-of-TOC/Change-Tab-Leader-of-TOC.csproj
@@ -8,10 +8,11 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Change_Tab_Leader_of_TOC</RootNamespace>
     <AssemblyName>Change-Tab-Leader-of-TOC</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -33,17 +34,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=19.1460.0.56, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.19.1.0.56\lib\net46\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=26.1462.42.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.26.1.42\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=19.1460.0.56, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.19.1.0.56\lib\net46\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=26.1462.42.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.26.1.42\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=19.1460.0.56, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.19.1.0.56\lib\net46\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=26.1462.42.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.26.1.42\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=19.1460.0.56, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.19.1.0.56\lib\net46\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=26.1462.42.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.26.1.42\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Change-Tab-Leader-of-TOC/Console-App-.NET-Framework/Change-Tab-Leader-of-TOC/packages.config
+++ b/Change-Tab-Leader-of-TOC/Console-App-.NET-Framework/Change-Tab-Leader-of-TOC/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="19.1.0.56" targetFramework="net472" />
-  <package id="Syncfusion.DocIO.WinForms" version="19.1.0.56" targetFramework="net472" />
-  <package id="Syncfusion.Licensing" version="19.1.0.56" targetFramework="net472" />
-  <package id="Syncfusion.OfficeChart.Base" version="19.1.0.56" targetFramework="net472" />
+  <package id="Syncfusion.Compression.Base" version="26.1.42" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="26.1.42" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="26.1.42" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="26.1.42" targetFramework="net462" />
 </packages>

--- a/Create-TOC/Console-App-.NET-Core/Create-TOC/Create-TOC.csproj
+++ b/Create-TOC/Console-App-.NET-Core/Create-TOC/Create-TOC.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Syncfusion.DocIORenderer.Net.Core" Version="18.2.0.44" />
+    <PackageReference Include="Syncfusion.DocIORenderer.Net.Core" Version="*" />
   </ItemGroup>
 
 </Project>

--- a/Customize-TOC-entry-styles/Console-App-.NET-Core/Customize-TOC-entries-style/Customize-TOC-entries-style.csproj
+++ b/Customize-TOC-entry-styles/Console-App-.NET-Core/Customize-TOC-entries-style/Customize-TOC-entries-style.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>customize_toc_entries_style</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Syncfusion.DocIORenderer.Net.Core" Version="18.2.0.44" />
+    <PackageReference Include="Syncfusion.DocIORenderer.Net.Core" Version="*" />
   </ItemGroup>
 
 </Project>

--- a/Edit-TOC/Console-App-.NET-Core/Edit-TOC/Edit-TOC.csproj
+++ b/Edit-TOC/Console-App-.NET-Core/Edit-TOC/Edit-TOC.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Syncfusion.DocIORenderer.Net.Core" Version="18.2.0.44" />
+    <PackageReference Include="Syncfusion.DocIORenderer.Net.Core" Version="*" />
   </ItemGroup>
 
 </Project>

--- a/Remove-TOC/Console-App-.NET-Core/Remove-TOC/Remove-TOC.csproj
+++ b/Remove-TOC/Console-App-.NET-Core/Remove-TOC/Remove-TOC.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Syncfusion.DocIORenderer.Net.Core" Version="18.2.0.44" />
+    <PackageReference Include="Syncfusion.DocIORenderer.Net.Core" Version="*" />
   </ItemGroup>
 
 </Project>

--- a/TOC-for-custom-styles/Console-App-.NET-Core/TOC-for-custom-styles/TOC-for-custom-styles.csproj
+++ b/TOC-for-custom-styles/Console-App-.NET-Core/TOC-for-custom-styles/TOC-for-custom-styles.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Syncfusion.DocIORenderer.Net.Core" Version="18.2.0.44" />
+    <PackageReference Include="Syncfusion.DocIORenderer.Net.Core" Version="*" />
   </ItemGroup>
 
 </Project>

--- a/Update-TOC/Console-App-.NET-Core/Update-TOC/Update-TOC.csproj
+++ b/Update-TOC/Console-App-.NET-Core/Update-TOC/Update-TOC.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Syncfusion.DocIORenderer.Net.Core" Version="18.2.0.44" />
+    <PackageReference Include="Syncfusion.DocIORenderer.Net.Core" Version="*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
1. Change Syncfusion NuGet versions with * instead of static version in all cross platform samples.
2. Cross platform samples should be .NET 8.0 target. (ASP.NET Core web app, Core console). Change the samples.
3. .NET Framework samples must be .NET 4.6.2 target.
4. Delete projects which reached end of .NET life cycle.