### PR TITLE
Upgrade the NuGet version to 30.1.37 in all .NET Framework projects -Word TOC Examples

### DIFF
--- a/Change-Tab-Leader-of-TOC/Console-App-.NET-Framework/Change-Tab-Leader-of-TOC/Change-Tab-Leader-of-TOC.csproj
+++ b/Change-Tab-Leader-of-TOC/Console-App-.NET-Framework/Change-Tab-Leader-of-TOC/Change-Tab-Leader-of-TOC.csproj
@@ -34,17 +34,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=29.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.29.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.30.1.37\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=29.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.29.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.30.1.37\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=29.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.29.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.30.1.37\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=29.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.29.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.30.1.37\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Change-Tab-Leader-of-TOC/Console-App-.NET-Framework/Change-Tab-Leader-of-TOC/packages.config
+++ b/Change-Tab-Leader-of-TOC/Console-App-.NET-Framework/Change-Tab-Leader-of-TOC/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="29.1.33" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="29.1.33" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="29.1.33" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="29.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="30.1.37" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="30.1.37" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="30.1.37" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="30.1.37" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
Upgraded the NuGet version to 30.1.37 in all .NET Framework projects for Word TOC Examples repository.